### PR TITLE
Drop Git LFS on main (fetch assets from bucket)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-*.so filter=lfs diff=lfs merge=lfs -text
-*.dll filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Removes Git LFS from `main`. Assets now come from the asset bucket, content-addressed by sha256 and verified before install.

- `.gitattributes`: file removed (was LFS-only)
- LFS pointers untracked and gitignored: 0
- Adds `.assets.manifest` (path -> sha256 -> size) and `fetch_assets.sh`

Objects are already uploaded and verified. `fetch_assets.sh` resolves via
`https://download.stereolabs.com/lfs` with direct B2 as fallback.