### PR TITLE
Drop Git LFS on release/4.5 (fetch assets from bucket)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-*.dll filter=lfs diff=lfs merge=lfs -text
-*.so filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
GitHub LFS is not an option — assets move to our B2 bucket, fetched by sha256 via `download.stereolabs.com/lfs` (direct B2 as fallback).

- `.gitattributes`: file removed (was LFS-only)
- LFS pointers untracked and gitignored: 0
- Adds `.assets.manifest` and `fetch_assets.sh`

Objects already uploaded and verified; a wrong or tampered object is rejected before install.