### PR TITLE
5.2.1

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -5,7 +5,7 @@ set SCRIPT_DIR=%~dp0
 REM Each dependency is versioned independently under its own path segment
 REM (<CDN_BASE>/<lib>/<version>/<archive>), so bumping one lib's version never forces
 REM re-uploading another unchanged lib.
-set "SL_ZED_VERSION=5.1.0"
+set "SL_ZED_VERSION=5.1.1"
 set "SL_ZED_SIM2REAL_VERSION=0.1.0"
 set "BUILD_PATH=_build\windows-x86_64\release\exts\sl.sensor.camera\bin"
 set "BIN_TARGET=exts\sl.sensor.camera\bin"

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ rm -f exts/sl.sensor.camera/bin/libsl.sensor.camera.plugin.so
 # Each dependency is versioned independently under its own path segment
 # (<CDN_BASE>/<lib>/<version>/<archive>), so bumping one lib's version never forces
 # re-uploading another unchanged lib.
-ZED_ISAAC_SIM_VERSION=5.1.0
+ZED_ISAAC_SIM_VERSION=5.1.1
 SL_ZED_SIM2REAL_VERSION=0.1.0
 echo "Downloading dependencies (sl_zed $ZED_ISAAC_SIM_VERSION, sl_zed_sim2real $SL_ZED_SIM2REAL_VERSION)..."
 

--- a/exts/sl.sensor.camera.calibration_exporter/premake5.lua
+++ b/exts/sl.sensor.camera.calibration_exporter/premake5.lua
@@ -1,0 +1,11 @@
+-- Pure-Python extension: no C++/OGN. This file exists only to stage the source folders
+-- into the build tree (_build/.../exts/<name>/) so the extension is discoverable by kit
+-- and publishable alongside sl.sensor.camera.
+local ext = get_current_extension_info()
+project_ext(ext)
+
+repo_build.prebuild_link {
+    { "data", ext.target_dir.."/data" },
+    { "docs", ext.target_dir.."/docs" },
+    { "sl/sensor/camera/", ext.target_dir.."/sl/sensor/camera/" },
+}

--- a/exts/sl.sensor.camera.demo/premake5.lua
+++ b/exts/sl.sensor.camera.demo/premake5.lua
@@ -1,0 +1,11 @@
+-- Pure-Python extension: no C++/OGN. This file exists only to stage the source folders
+-- into the build tree (_build/.../exts/<name>/) so the extension is discoverable by kit
+-- and publishable alongside sl.sensor.camera.
+local ext = get_current_extension_info()
+project_ext(ext)
+
+repo_build.prebuild_link {
+    { "data", ext.target_dir.."/data" },
+    { "docs", ext.target_dir.."/docs" },
+    { "sl/sensor/camera/", ext.target_dir.."/sl/sensor/camera/" },
+}

--- a/exts/sl.sensor.camera/config/extension.toml
+++ b/exts/sl.sensor.camera/config/extension.toml
@@ -1,5 +1,5 @@
 [package]
-version = "5.2.0" # Semantic Versioning is used: https://semver.org/
+version = "5.2.1" # Semantic Versioning is used: https://semver.org/
 
 # These fields are used primarily for display in the extension browser UI.
 title = "Stereolabs ZED Camera"

--- a/exts/sl.sensor.camera/docs/CHANGELOG.md
+++ b/exts/sl.sensor.camera/docs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [5.2.1]
+### Fixes
+- Fixed a crash a few seconds after a stereo stream started on Linux when the transport mode was `IPC` or `BOTH`. Isaac Sim exited silently, with no crash report.
+- A camera that fails to start streaming is now recoverable: stop and play again. Previously every later attempt failed until Isaac Sim was restarted, whatever the port was set to. The failure is also reported once instead of every frame.
+- Deleting one ZED camera no longer stops the other cameras streaming in the same scene.
+
 ## [5.2.0]
 ### New features
 - Added the calibrated **ZED Sim2Real camera model**, an optional post-process that makes simulated RGB resemble a real ZED X camera (lens blur, vignetting, temporal auto-exposure, color grading, sensor noise). Enable it via the **ZED Sim2Real Apply** option on the ZED Camera Helper node, or pass `--apply_zed_sim2real` to the Isaac Lab examples (`zed_single.py`, `zed_multi_env.py`).

--- a/exts/sl.sensor.camera/docs/README.md
+++ b/exts/sl.sensor.camera/docs/README.md
@@ -210,7 +210,12 @@ the configured port (network) or via IPC on `127.0.0.1` (same machine).
   streaming additionally relies on `ingestCustomDepth` (ZED SDK >= 5.4.0).
 - **First frame is slow / appears to hang.** The first rendered frame compiles RTX shaders and can take
   minutes on a cold cache. It is compiling, not stuck.
-- **Multiple cameras conflict.** Give each camera its own even port; port reuse is rejected.
+- **`Streamer initialization failed` in the console.** Most often the port is already in use or is not
+  even. Check the port reported in the message, then **Stop and Play again** - the camera does not retry
+  on its own within a session.
+- **Multiple cameras conflict.** Give each camera its own even port; port reuse is rejected. On IPC (or
+  the `BOTH` transport mode), closing one camera's stream currently also interrupts IPC delivery for the
+  other cameras in the scene; their network streams are unaffected.
 - **Wrong intrinsics / baseline.** Use the shipped ZED USD models (with their authored
   `CameraLeft`/`CameraRight` prims), not ad-hoc pinhole cameras, so intrinsics and baseline match the
   real hardware.

--- a/exts/sl.sensor.camera/include/zed_interface_loader.hpp
+++ b/exts/sl.sensor.camera/include/zed_interface_loader.hpp
@@ -211,7 +211,7 @@ namespace sl
             {
                 CARB_LOG_INFO("IPC stream enabled");
             }
-            CARB_LOG_WARN("[ZED] Initializing streamer with ID %d on port %d", streamer_id, streaming_params->port);
+            CARB_LOG_INFO("[ZED] Initializing streamer with ID %d on port %d", streamer_id, streaming_params->port);
 
             return init_streamer(streamer_id, streaming_params);
         }

--- a/exts/sl.sensor.camera/plugins/nodes/OgnZEDSimCameraNode.cpp
+++ b/exts/sl.sensor.camera/plugins/nodes/OgnZEDSimCameraNode.cpp
@@ -378,6 +378,9 @@ namespace sl {
                 // One-shot guard for the input-buffer-size mismatch below.
                 bool m_size_warned{ false };
 
+                // Set when streamer init fails, so the failure is reported once instead of every frame.
+                bool m_streamerInitFailed{ false };
+
                 // Fallback clock: some Isaac builds deliver simulationTime == 0 from the
                 // SDG time nodes; without a monotonic time the warmup gate and the
                 // frame-dedup logic would stall the streamer.
@@ -484,10 +487,9 @@ public:
                         m_owns_pool_serial = false;
                     }
 
-                    // Clean up ZED streamer
+                    // Clean up ZED streamer.
                     if (m_zedStreamerInitStatus == 1) {
                         m_zedStreamer.closeStreamer(m_streamer_id);
-                        m_zedStreamer.destroyInstance();
                         freeStreamerId(m_streamer_id);
                         m_zedStreamerInitStatus = 0;
                     }
@@ -519,8 +521,10 @@ public:
                     }
                     if (!db.inputs.stream()) {
                         // Streaming simply turned off - nothing to do this frame.
+                        state.m_streamerInitFailed = false;
                         return false;
                     }
+                    if (state.m_streamerInitFailed) return false;
 
                     // Robust frame time: prefer simulationTime, fall back to an internal
                     // steady clock when the upstream time nodes deliver 0 (Isaac build
@@ -672,7 +676,13 @@ public:
                             state.m_streamingThread = std::thread(&OgnZEDSimCameraNode::streamingThreadFunc, std::ref(state));
                         }
                         else {
-                            CARB_LOG_ERROR("[ZED] Error during zed streamer initialization %d", state.m_zedStreamerInitStatus);
+                            state.m_streamerInitFailed = true;
+                            CARB_LOG_ERROR("[ZED] Streamer initialization failed. "
+                                "Camera %s SN %d, port %d, %dx%d @ %d FPS.",
+                                camera_model.c_str(), serial_number, static_cast<int>(port),
+                                state.m_zedStreamerParams.image_width, state.m_zedStreamerParams.image_height,
+                                state.m_zedStreamerParams.fps);
+                            state.m_zedStreamer.closeStreamer(state.m_streamer_id);
                             freeStreamerId(state.m_streamer_id);
                             if (owns_pool_serial)
                                 removeStreamer(camera_model, serial_number);

--- a/premake5.lua
+++ b/premake5.lua
@@ -20,3 +20,5 @@ end
 dofile("_repo/deps/repo_kit_tools/kit-template/premake5.lua")
 
 include("exts/sl.sensor.camera/premake5.lua")
+include("exts/sl.sensor.camera.calibration_exporter/premake5.lua")
+include("exts/sl.sensor.camera.demo/premake5.lua")

--- a/repo.toml
+++ b/repo.toml
@@ -43,3 +43,15 @@ ext_folders = [
 
 [repo_symstore]
 enabled = false
+
+[repo_publish_exts]
+# Publish exactly these three extensions (explicit, so default discovery can never pull in
+# a dependency by accident). All three must be staged into _build/.../exts/ first, which the
+# per-extension premake5.lua files handle.
+exts.include = [
+    "sl.sensor.camera",
+    "sl.sensor.camera.calibration_exporter",
+    "sl.sensor.camera.demo",
+]
+# No codesign certs on dev machines; publish unsigned. Re-enable if publishing from CI.
+signing.enabled = false


### PR DESCRIPTION
## [5.2.1]

### Fixes

- Fixed a crash a few seconds after a stereo stream started on Linux when the transport mode was IPC or BOTH. Isaac Sim exited silently, with no crash report.
- A camera that fails to start streaming is now recoverable: stop and play again. Previously every later attempt failed until Isaac Sim was restarted, whatever the port was set to. The failure is also reported once instead of every frame.
- Deleting one ZED camera no longer stops the other cameras streaming in the same scene.